### PR TITLE
fix for stackoverflow and workaround for reddit

### DIFF
--- a/reddit/import.janet
+++ b/reddit/import.janet
@@ -24,8 +24,12 @@
 
 
 (defn posts-json []
-  (let [response (http/get "https://old.reddit.com/r/clojure.json")]
-    (json/decode (get response :body) true true)))
+  (let [url "https://old.reddit.com/r/clojure.json"
+        response (http/get url)]
+    (if (= (get response :status) 200)
+      (json/decode (get response :body) true true)
+      (do (printf "Unexpected result from %s\n%q" url response)
+          {:data {:children []}}))))
 
 
 (defn posts-since [time]

--- a/stackoverflow/import.janet
+++ b/stackoverflow/import.janet
@@ -8,7 +8,7 @@
 (def url (string/format "https://api.stackexchange.com/2.2/questions?fromdate=%d&order=desc&sort=activity&tagged=clojure&site=stackoverflow"
                         four-days-ago))
 
-(def response (http/get url))
+(def response (http/get url :headers {"Accept-Encoding" "gzip"}))
 
 (with [f (file/open "results.json.gz" :wb)]
   (file/write f (get response :body)))

--- a/version/import.janet
+++ b/version/import.janet
@@ -4,7 +4,11 @@
 
 (def url "https://search.maven.org/solrsearch/select?q=a:clojure&start=0&rows=20")
 (def response (http/get url))
-(def data (json/decode (get response :body) true true))
+(def data (if (= (get response :status) 200)
+            (json/decode (get response :body) true true)
+            (do (printf "Unexpected result from %s\n%q" url response)
+                {:response {:docs[{:latestVersion "unknown"
+                                   :timestamp 0}]}})))
 
 (def result {:name (get-in data [:response :docs 0 :latestVersion])
              :published-at (/ (get-in data [:response :docs 0 :timestamp])


### PR DESCRIPTION
Hello!
I noticed that for some time todayinclojure.com hasn't been refreshing. I identified two problems:
1. Stack Overflow wasn't returning data as gzip. I added a header `{"Accept-Encoding" "gzip"}` to the request.
2. Reddit is blocking requests from the github's worker IP address (https://old.reddit.com/r/help/comments/199uvsb/your_request_has_been_blocked_due_to_a_network/). It works fine locally and on a self-hosted worker. I added a change that skips further processing if the status is different from 200.
The changes in this PR should restore the refreshing functionality. Unfortunately, if run on a GitHub worker, it will skip Reddit.